### PR TITLE
:sparkles: add ability to flatten versions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "Bash(composer show:*)",
       "Bash(composer info:*)",
       "Bash(composer why-not:*)",
-      "Bash(vendor/bin/duster fix:*)"
+      "Bash(vendor/bin/duster fix:*)",
+      "Bash(git checkout:*)"
     ],
     "deny": [],
     "ask": []

--- a/tests/Feature/ModelVersioningTest.php
+++ b/tests/Feature/ModelVersioningTest.php
@@ -29,12 +29,15 @@ test('complete versioning workflow', function () {
 
     // Update the model multiple times
     $model->update(['name' => 'Updated Name']);
+    $model->refresh();
     expect($model->versions)->toHaveCount(2);
 
     $model->update(['description' => 'Updated Description']);
+    $model->refresh();
     expect($model->versions)->toHaveCount(3);
 
     $model->update(['data' => ['status' => 'published']]);
+    $model->refresh();
     expect($model->versions)->toHaveCount(4);
 
     // Test version retrieval
@@ -62,10 +65,12 @@ test('versioning with configuration changes', function () {
     expect($model->versions)->toHaveCount(1);
 
     $model->update(['name' => 'Updated']);
+    $model->refresh();
     expect($model->versions)->toHaveCount(1); // No new version created
 
     // Manually create version
     $model->createVersion('Manual version');
+    $model->refresh();
     expect($model->versions)->toHaveCount(2)
         ->and($model->getCurrentVersion()->comment)->toBe('Manual version');
 });
@@ -75,9 +80,11 @@ test('versioning with disabled restore versioning', function () {
 
     $model = TestModel::create(['name' => 'Original']);
     $model->update(['name' => 'Updated']);
+    $model->refresh();
     expect($model->versions)->toHaveCount(2);
 
     $model->restoreToVersion(1);
+    $model->refresh();
     expect($model->versions)->toHaveCount(2); // No new version created on restore
 });
 
@@ -95,11 +102,10 @@ test('performance with multiple versions', function () {
     // Test that versions are properly ordered
     $versions = $model->versions;
     $versionNumbers = $versions->pluck('version_number')->toArray();
-    expect($versionNumbers)->toBe(range(51, 1));
-
-    // Test specific version retrieval
     $version25 = $model->getVersion(25);
-    expect($version25->data['description'])->toBe('Version 24 description');
+
+    expect($versionNumbers)->toBe(range(51, 1))
+        ->and($version25->data['description'])->toBe('Version 24 description');
 });
 
 test('versioning without authentication', function () {
@@ -145,5 +151,6 @@ test('complex data versioning', function () {
 
     // Restore to previous version
     $model->restoreToVersion(1);
+    $model->refresh();
     expect($model->data['settings']['theme'])->toBe('dark');
 });


### PR DESCRIPTION
This pull request introduces a new utility method for managing model version history and improves test reliability and readability for model versioning. The most notable change is the addition of the `flattenVersions` method, which deletes all but the latest version of a model. The tests have also been updated to ensure version relationships are accurate after updates and to consolidate assertions for better clarity.

**Model Versioning Enhancements:**

* Added a new `flattenVersions` method to the `HasVersions` trait, allowing deletion of all but the latest version for a model. This helps manage version history and storage.
* Thoroughly tested the new `flattenVersions` method with various scenarios, including cases with multiple, single, or no versions.

**Test Improvements:**

* Updated feature tests to call `$model->refresh()` after updates and restores, ensuring the `versions` relationship is always up-to-date and assertions reflect the actual state. [[1]](diffhunk://#diff-7088cd6719bc741cb77e22779b7c0f01511520767700eb9755f2e91474c41810R32-R40) [[2]](diffhunk://#diff-7088cd6719bc741cb77e22779b7c0f01511520767700eb9755f2e91474c41810R68-R73) [[3]](diffhunk://#diff-7088cd6719bc741cb77e22779b7c0f01511520767700eb9755f2e91474c41810R83-R87) [[4]](diffhunk://#diff-7088cd6719bc741cb77e22779b7c0f01511520767700eb9755f2e91474c41810R154)
* Consolidated multiple `expect` assertions into single chained statements for improved readability and maintainability in unit tests. [[1]](diffhunk://#diff-2017141cf7728f12e6440ae496698a8aca2ce94c058dd57cf7febd5d9cd6e0a2L57-R59) [[2]](diffhunk://#diff-2017141cf7728f12e6440ae496698a8aca2ce94c058dd57cf7febd5d9cd6e0a2L69-R86) [[3]](diffhunk://#diff-2017141cf7728f12e6440ae496698a8aca2ce94c058dd57cf7febd5d9cd6e0a2L119-R120) [[4]](diffhunk://#diff-2017141cf7728f12e6440ae496698a8aca2ce94c058dd57cf7febd5d9cd6e0a2L160-R163) [[5]](diffhunk://#diff-2017141cf7728f12e6440ae496698a8aca2ce94c058dd57cf7febd5d9cd6e0a2L187-R190) [[6]](diffhunk://#diff-2017141cf7728f12e6440ae496698a8aca2ce94c058dd57cf7febd5d9cd6e0a2L203-R205) [[7]](diffhunk://#diff-2017141cf7728f12e6440ae496698a8aca2ce94c058dd57cf7febd5d9cd6e0a2L231-R232)

**Configuration Update:**

* Allowed `git checkout` commands in the local Claude settings, expanding the permitted command set for development workflows.